### PR TITLE
docs: declare verbose as optional parameter in init function

### DIFF
--- a/src/plan.js
+++ b/src/plan.js
@@ -108,7 +108,7 @@ module.exports = class Plan {
    * It's to keep a context in a singleton (retrieved via inject()).
    * A context in a singleton is usefull to be used in files that are not in the context.
    * @param item
-   * @param verbose
+   * @param {boolean} [verbose]
    */
   static init(item, verbose) {
     Plan.execute(item, Plan._context = new Context(), verbose);


### PR DESCRIPTION
The fact that `verbose` is not used is detected as a problem with typescript/eslint

## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
