### PR TITLE
feat(addUsingClass): provide more detailled error

### DIFF
--- a/src/context.js
+++ b/src/context.js
@@ -149,7 +149,7 @@ module.exports = class Context {
 
   addUsingClass(path, name, Class, options) {
     this._metadata.add(path, name, 'class', Class, options);
-    const instance = this._instanciate(Class, options);
+    const instance = this._instanciate(path, name, Class, options);
     this._setNewValue(name, instance, options);
     return this;
   }
@@ -169,10 +169,15 @@ module.exports = class Context {
     return this;
   }
 
-  _instanciate(Class, { map } = {}) {
-    const RealClass = Class.toString().startsWith('class') ? Class : Class();
-    if (!map) return new RealClass(this.get());
-    return new RealClass(this._mapContext(map));
+  _instanciate(path, name, FunctionFactory, { map } = {}) {
+    try {
+      const isClass = FunctionFactory.toString().startsWith('class');
+      const ClassToInstanciate = isClass ? FunctionFactory : FunctionFactory();
+      const localContext = map ? this._mapContext(map) : this.get();
+      return new ClassToInstanciate(localContext);
+    } catch (cause) {
+      throw new Error(`instanciating a value for path "${path}/${name}"`, { cause });
+    }
   }
 
   static _makeMapping(bag, map) {

--- a/test/unit/context.unit.test.js
+++ b/test/unit/context.unit.test.js
@@ -29,4 +29,15 @@ describe('Context', () => {
     expect(() => Context._makeMapping(bag, map))
       .toThrow('mapping error, key(s) not found: from, foo');
   });
+
+  describe('_instantiate failure', () => {
+    it('passing anything but a function factory or a class', () => {
+      expect(() => new Context()._instanciate('foo', 'bar', 'bad-value'))
+        .toThrow('instanciating a value for path "foo/bar"');
+    });
+    it('passing a function factory that does not return a class', () => {
+      expect(() => new Context()._instanciate('foo', 'bar', () => 'bad-value'))
+        .toThrow('instanciating a value for path "foo/bar"');
+    });
+  });
 });


### PR DESCRIPTION
When making errors using `addUsingClass`, message error is now detailed:

```
Error: instanciating a value for path "foo/barService"
        at Context._instanciate (/Users/slim/repos/context/src/context.js:179:13)
        at Object._instanciate (/Users/slim/repos/context/test/unit/context.unit.test.js:40:23)
        ... 13 lines matching cause stack trace ...
        at runTest (/Users/slim/repos/context/node_modules/jest-runner/build/runTest.js:444:34) {
      [cause]: TypeError: ClassToInstanciate is not a constructor
          at Context._instanciate (/Users/slim/repos/context/src/context.js:177:14)
          at Object._instanciate (/Users/slim/repos/context/test/unit/context.unit.test.js:40:23)

```
## Definition of Done

### General

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
